### PR TITLE
(CLOUD-1321) Updating default vm size for better performance

### DIFF
--- a/mainTemplate.json
+++ b/mainTemplate.json
@@ -11,7 +11,7 @@
     },
     "vmSize": {
       "type":"string",
-      "defaultValue": "Standard_A4_v2",
+      "defaultValue": "Standard_D3_v2",
       "metadata":{
         "description":"VM Size"
       }


### PR DESCRIPTION
When the default VM size was set to Standard_A4_v2 puppet runs were taking 30 seconds when we would expect the average to be around 10. Spoke with Kenaz who advised to test with Standard_D3_v2. This box gets us to an average puppet runtime of around 10 seconds. I have updated the main template to use this size as the default.