### PR TITLE
Add duration and login details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpuppetlabs%2Fazure-image%2Fmaster%2FmainTemplate.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
 
 
-This template launches a Puppet Enterprise Master VM.
+This template launches a Puppet Enterprise Master VM. It takes around 15 minutes to deploy.
+
+After deployment completes, login to the web console with username <code>admin</code> and password <code>puppet</code>.
 
 This template contains extra parameters to allow for the existing resources use cases, which is a common scenario for Solution Templates in the Azure Marketplace.


### PR DESCRIPTION
It wasn't immediately obvious that deployment takes 15 minutes, nor did the Readme provide the default login credentials. This PR fixes that.